### PR TITLE
modifiche alla rimozione carta dalla collezione

### DIFF
--- a/Pokemine/src/main/java/com/astrategy/pokemine/services/UserCollectionServiceImp.java
+++ b/Pokemine/src/main/java/com/astrategy/pokemine/services/UserCollectionServiceImp.java
@@ -3,15 +3,10 @@ package com.astrategy.pokemine.services;
 import java.util.List;
 import java.util.Optional;
 
+import com.astrategy.pokemine.entities.*;
+import com.astrategy.pokemine.repos.*;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.astrategy.pokemine.entities.Card;
-import com.astrategy.pokemine.entities.UserCollectionId;
-import com.astrategy.pokemine.entities.UserCollection;
-import com.astrategy.pokemine.entities.User;
-import com.astrategy.pokemine.repos.CardDAO;
-import com.astrategy.pokemine.repos.UserCollectionDAO;
-import com.astrategy.pokemine.repos.UserDAO;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,6 +18,10 @@ public class UserCollectionServiceImp implements UserCollectionService {
 	private UserDAO userDAO;
 	@Autowired 
 	private CardDAO carddao;
+	@Autowired
+	private DeckDAO deckDAO;
+	@Autowired
+	private DeckCardDAO deckCardDAO;
 
 	// Method to add a card to the user's collection
 	@Override
@@ -76,10 +75,40 @@ public class UserCollectionServiceImp implements UserCollectionService {
 			if (userCollection.getQuantity() > 1) {
 				userCollection.setQuantity(userCollection.getQuantity() - 1);
 				dao.save(userCollection);
+				// If the card is present in any deck, its quantity can't be bigger
+				// than the quantity in the collection
+				List<Deck> userDecks = deckDAO.findByUserId(userId);
+				for (Deck deck : userDecks) {
+					List<DeckCard> cardsInDeck = deckCardDAO.findByDeck(deck);
+					for (DeckCard deckCard : cardsInDeck) {
+						if (deckCard.getCard().equals(card)) {
+							// if the quantity in the deck is greater than the collection
+							// set the deck quantity to the collection quantity
+							// so the user still has the maximum amount available
+							if(deckCard.getQuantity()>userCollection.getQuantity()){
+								deckCard.setQuantity(userCollection.getQuantity());
+								deckCardDAO.save(deckCard);
+							}
+						}
+					}
+				}
 			} else {
 				// If the quantity is 1 or less, remove the card from the collection
 				dao.delete(userCollection);
+				// if the card gets removed from the collection, it must be also removed
+				// from the decks
+				List<Deck> userDecks = deckDAO.findByUserId(userId);
+				for (Deck deck : userDecks) {
+					List<DeckCard> cardsInDeck = deckCardDAO.findByDeck(deck);
+					for (DeckCard deckCard : cardsInDeck) {
+						if (deckCard.getCard().equals(card)) {
+							deckCardDAO.delete(deckCard);
+						}
+					}
+				}
 			}
+
+
 		} else {
 			throw new RuntimeException("The card does not exist in the collection.");
 		}


### PR DESCRIPTION
implementato controllo sulla quantità di carte possedute nella collezione e la quantità nei mazzi: nel deck non possono esserci più carte nel mazzo di quelle possedute nella collezione